### PR TITLE
dnssec-debugger changed URL

### DIFF
--- a/dnsvizwww/templates/dnssec.html
+++ b/dnsvizwww/templates/dnssec.html
@@ -208,7 +208,7 @@
 
 			<div id="see-also">
 				<h3>See also</h3>
-				<a href="http://dnssec-debugger.verisignlabs.com/{{ name_obj.to_text }}">DNSSEC Debugger</a> by <a href="http://www.verisignlabs.com/">Verisign Labs</a>.
+				<a href="https://dnssec-analyzer.verisignlabs.com/{{ name_obj.to_text }}">DNSSEC Analyzer</a> by <a href="http://www.verisignlabs.com/">Verisign Labs</a>.
 			</div>
 
 		</div> <!-- notices-region -->


### PR DESCRIPTION
http://dnssec-debugger.verisignlabs.com/ retrurns 302
https://dnssec-analyzer.verisignlabs.com/

```
curl http://dnssec-debugger.verisignlabs.com/
<!DOCTYPE HTML PUBLIC "-//IETF//DTD HTML 2.0//EN">
<html><head>
<title>302 Found</title>
</head><body>
<h1>Found</h1>
<p>The document has moved <a href="https://dnssec-analyzer.verisignlabs.com/">here</a>.</p>
</body></html>
```