### PR TITLE
Use https

### DIFF
--- a/dnsvizwww/templates/analyze.html
+++ b/dnsvizwww/templates/analyze.html
@@ -7,7 +7,7 @@
 	<!-- Javascripts and associated styles -->
 	<script type="text/javascript" src="{% static "js/jquery-ui-1.10.4.custom.min.js" %}"></script>
 	<link rel="stylesheet" href="{% static "css/redmond/jquery-ui-1.10.4.custom.min.css" %}" />
-	<script src="http://java.com/js/dtjava.js"></script>
+	<script src="https://java.com/js/dtjava.js"></script>
 	<script type="text/javascript">
 		<!--
 		$(document).ready(function() {

--- a/dnsvizwww/templates/contact.html
+++ b/dnsvizwww/templates/contact.html
@@ -6,7 +6,7 @@
 
 {% block maincontent %}
 <h3>Contact</h3>
-<p>DNSViz was developed by <a href="http://casey.byu.edu/">Casey Deccio</a>, originally at <a href="http://www.sandia.gov/">Sandia National Laboratories</a>.  <a href="http://www.verisignlabs.com/">Verisign Labs</a> continues to sponsor ongoing development of DNSViz.</p>
+<p>DNSViz was developed by <a href="https://casey.byu.edu/">Casey Deccio</a>, originally at <a href="https://www.sandia.gov/">Sandia National Laboratories</a>.  <a href="https://www.verisignlabs.com/">Verisign Labs</a> continues to sponsor ongoing development of DNSViz.</p>
 <p>Please use the form below to contact us with your comments and questions.  We appreciate your feedback!</p>
 	<form action="" method="post">
 		{% csrf_token %}

--- a/dnsvizwww/templates/dnssec.html
+++ b/dnsvizwww/templates/dnssec.html
@@ -208,7 +208,7 @@
 
 			<div id="see-also">
 				<h3>See also</h3>
-				<a href="http://dnssec-debugger.verisignlabs.com/{{ name_obj.to_text }}">DNSSEC Debugger</a> by <a href="http://www.verisignlabs.com/">Verisign Labs</a>.
+				<a href="https://dnssec-debugger.verisignlabs.com/{{ name_obj.to_text }}">DNSSEC Debugger</a> by <a href="https://www.verisignlabs.com/">Verisign Labs</a>.
 			</div>
 
 		</div> <!-- notices-region -->

--- a/dnsvizwww/templates/dnssec_legend.html
+++ b/dnsvizwww/templates/dnssec_legend.html
@@ -147,7 +147,7 @@
 					indicates that the DNSKEY has been designated as a <strong>trust
 						anchor</strong>.</p><p>By default DNSViz uses the the KSK for the
 					root zone as the exclusive trust anchor (the KSK for <a
-						href="http://www.isc.org/">Internet Systems Consortium's (ISC)</a> <a
+						href="https://www.isc.org/">Internet Systems Consortium's (ISC)</a> <a
 						href="https://dlv.isc.org/">DNSSEC Look-aside Validation (DLV)
 						registry</a> is also currently included but will be going away in the
 					near future).  This anchor may be de-selected, and/or any arbitrary

--- a/dnsvizwww/templates/domain_page.html
+++ b/dnsvizwww/templates/domain_page.html
@@ -3,7 +3,7 @@
 {% load static %}
 
 {% block extra_media %}
-	<script type="text/javascript" src="http://platform.twitter.com/widgets.js" ></script>
+	<script type="text/javascript" src="https://platform.twitter.com/widgets.js" ></script>
 	<script type="text/javascript" src="https://apis.google.com/js/plusone.js">
 		{lang:'en-US', parsetags:'explicit'}
 	</script>


### PR DESCRIPTION
Trying to address:
```
dnssec/:1 Mixed Content: The page at 'https://dnsviz.net/d/.../dnssec/' was loaded over HTTPS, but requested an insecure script 'http://platform.twitter.com/widgets.js'. This request has been blocked; the content must be served over HTTPS.
plusone.js:67 Mixed Content: The page at 'https://dnsviz.net/d/.../dnssec/' was loaded over HTTPS, but requested an insecure frame 'http://developers.google.com/#_methods=onPlusOne%2C_ready%2C_close%2C_open%2C_resizeMe%2C_renderstart%2Concircled%2Cdrefresh%2Cerefresh&id=I0_1698355622643&_gfid=I0_1698355622643&parent=https%3A%2F%2Fdnsviz.net&pfname=&rpctoken=28983084'. This request has been blocked; the content must be served over HTTPS.
```